### PR TITLE
feat(pass_keys): support fzf for key passthrough

### DIFF
--- a/pass_keys.py
+++ b/pass_keys.py
@@ -3,13 +3,16 @@ import re
 from kittens.tui.handler import result_handler
 from kitty.key_encoding import KeyEvent, parse_shortcut
 
-VIM_ID = "n?vim"
+PASSTHROUGH = r'\b(vim|nvim|fzf)\b'
 
 
-def is_window_vim(window):
+def is_window_passthrough(window):
     fp = window.child.foreground_processes
     return any(
-        re.search(VIM_ID, p["cmdline"][0] if len(p["cmdline"]) else "", re.I)
+        # Using cmdline[0] for now.
+        # For something like 'zoxide query | fzf'
+        # the actual binary receiving input might be the last element, so [-1] could be needed.
+        re.search(PASSTHROUGH, p['cmdline'][0] if len(p['cmdline']) else '', re.IGNORECASE)
         for p in fp
     )
 
@@ -42,8 +45,8 @@ def handle_result(args, result, target_window_id, boss):
 
     if window is None:
         return
-    if is_window_vim(window):
-        for keymap in key_mapping.split(">"):
+    if is_window_passthrough(window):
+        for keymap in key_mapping.split('>'):
             encoded = encode_key_mapping(window, keymap)
             window.write_to_child(encoded)
     else:

--- a/pass_keys.py
+++ b/pass_keys.py
@@ -6,15 +6,17 @@ from kitty.key_encoding import KeyEvent, parse_shortcut
 PASSTHROUGH = r'\b(vim|nvim|fzf)\b'
 
 
+# Return True if any foreground process in the window matches PASSTHROUGH
 def is_window_passthrough(window):
+
     fp = window.child.foreground_processes
-    return any(
-        # Using cmdline[0] for now.
-        # For something like 'zoxide query | fzf'
-        # the actual binary receiving input might be the last element, so [-1] could be needed.
-        re.search(PASSTHROUGH, p['cmdline'][0] if len(p['cmdline']) else '', re.IGNORECASE)
-        for p in fp
-    )
+
+    # Check if any argument in a process's cmdline matches PASSTHROUGH,
+    # including when launched via wrappers or pipelines (e.g., "zoxide query | fzf")
+    def is_process_passthrough(p):
+        return any(re.search(PASSTHROUGH, arg, re.IGNORECASE) for arg in p['cmdline'])
+
+    return any(is_process_passthrough(p) for p in fp)
 
 
 def encode_key_mapping(window, key_mapping):


### PR DESCRIPTION
Hi, 

as discussed in the issues I'm proposing here a change to allow `fzf` to be considered "passthrough", same as vim/nvim.

At the moment the default `fzf` keybindings `ctrl+j /` `ctrl+k` are not working. This change fixes it.

The regex has also been hardened.

This is my first PR, hope it's ok!

Bye! 